### PR TITLE
WriteValue - add type param 

### DIFF
--- a/src/GattCharacteristic.js
+++ b/src/GattCharacteristic.js
@@ -33,13 +33,13 @@ class GattCharacteristic extends EventEmitter {
     return Buffer.from(payload)
   }
 
-  async writeValue (value, offset = 0) {
+  async writeValue (value, offset = 0, type = 'reliable') {
     if (!Buffer.isBuffer(value)) {
       throw new Error('Only buffers can be wrote')
     }
     const options = {
       offset: buildTypedValue('uint16', offset),
-      type: buildTypedValue('string', 'reliable')
+      type: buildTypedValue('string', type)
     }
     const { data } = value.toJSON()
     await this.helper.callMethod('WriteValue', data, options)


### PR DESCRIPTION
According to Bluez API (https://github.com/hadess/bluez/blob/master/doc/gatt-api.txt) you can specify the write type (eg: Write without response)

This PR aim to add this type parameter to WriteValue 

Here is the allowed types : 
```
"command": Write without response
"request": Write with response
"reliable": Reliable Write
``` 

