### PR TITLE
fix(adapter.waitDevice): cancel timers on exception

### DIFF
--- a/src/Adapter.js
+++ b/src/Adapter.js
@@ -99,11 +99,14 @@ class Adapter {
       cancellable.push(() => clearTimeout(handler))
     })
 
-    const device = await Promise.race([discoveryHandler, timeoutHandler])
+    Promise.race([discoveryHandler, timeoutHandler])
+      .finally(() => {
+        for (const cancel of cancellable) {
+          cancel()
+        }
+      })
 
-    for (const cancel of cancellable) {
-      cancel()
-    }
+    const device = await Promise.race([discoveryHandler, timeoutHandler])
     return device
   }
 


### PR DESCRIPTION
My end-to-end tests use node-ble. When bluetooth device is not found, my tests finish but program hangs. I used package why-is-node-running to track down problem to `adapter.waitDevice`. 