### PR TITLE
writeValue - options improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const {bluetooth, destroy} = createBluetooth()
 | `Promise<String[]> getFlags()` | Defines how the characteristic value can be used. |
 | `Promise<bool> isNotifying()` | True, if notifications or indications on this characteristic are currently enabled. |
 | `Promise<Buffer> readValue(Number offset = 0)` | Issues a request to read the value of the characteristic and returns the value if the operation was successful. |
-| `Promise<void> writeValue(Buffer buffer, Number offset = 0)` | Issues a request to write the value of the characteristic. |
+| `Promise<void> writeValue(Buffer buffer, WriteValueOptions options = {})` | Issues a request to write the value of the characteristic. Default options `{ offset: 0, type: 'reliable' }`. |
 | `Promise<void> startNotifications()` | Starts a notification session from this characteristic if it supports value notifications or indications. |
 | `Promise<void> stopNotifications()` | This method will cancel any previous StartNotify transaction. |
 | `Promise<String> toString()` | User friendly characteristic name. |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const {bluetooth, destroy} = createBluetooth()
 | `Promise<String[]> getFlags()` | Defines how the characteristic value can be used. |
 | `Promise<bool> isNotifying()` | True, if notifications or indications on this characteristic are currently enabled. |
 | `Promise<Buffer> readValue(Number offset = 0)` | Issues a request to read the value of the characteristic and returns the value if the operation was successful. |
-| `Promise<void> writeValue(Buffer buffer, WriteValueOptions options = {})` | Issues a request to write the value of the characteristic. Default options `{ offset: 0, type: 'reliable' }`. |
+| `Promise<void> writeValue(Buffer buffer, Number | WriteValueOptions options = {})` | Issues a request to write the value of the characteristic. Default options `{ offset: 0, type: 'reliable' }`. |
 | `Promise<void> startNotifications()` | Starts a notification session from this characteristic if it supports value notifications or indications. |
 | `Promise<void> stopNotifications()` | This method will cancel any previous StartNotify transaction. |
 | `Promise<String> toString()` | User friendly characteristic name. |

--- a/src/GattCharacteristic.js
+++ b/src/GattCharacteristic.js
@@ -33,11 +33,12 @@ class GattCharacteristic extends EventEmitter {
     return Buffer.from(payload)
   }
 
-  async writeValue (value, options = {}) {
+  async writeValue (value, optionsOrOffset = {}) {
     if (!Buffer.isBuffer(value)) {
       throw new Error('Only buffers can be wrote')
     }
 
+    const options = typeof optionsOrOffset === 'number' ? { offset: optionsOrOffset } : optionsOrOffset
     const mergedOptions = Object.assign({ offset: 0, type: 'reliable' }, options)
 
     const callOptions = {

--- a/src/GattCharacteristic.js
+++ b/src/GattCharacteristic.js
@@ -33,16 +33,20 @@ class GattCharacteristic extends EventEmitter {
     return Buffer.from(payload)
   }
 
-  async writeValue (value, offset = 0) {
+  async writeValue (value, options = {}) {
     if (!Buffer.isBuffer(value)) {
       throw new Error('Only buffers can be wrote')
     }
-    const options = {
-      offset: buildTypedValue('uint16', offset),
-      type: buildTypedValue('string', 'reliable')
+
+    const mergedOptions = Object.assign({ offset: 0, type: 'reliable' }, options)
+
+    const callOptions = {
+      offset: buildTypedValue('uint16', mergedOptions.offset),
+      type: buildTypedValue('string', mergedOptions.type)
     }
+
     const { data } = value.toJSON()
-    await this.helper.callMethod('WriteValue', data, options)
+    await this.helper.callMethod('WriteValue', data, callOptions)
   }
 
   async startNotifications () {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace NodeBle {
         getFlags(): Promise<string[]>;
         isNotifying(): Promise<boolean>;
         readValue(offset?: number): Promise<Buffer>;
-        writeValue(buffer: Buffer, offset?: number): Promise<void>;
+        writeValue(buffer: Buffer, options?: WriteValueOptions): Promise<void>;
         startNotifications(): Promise<void>;
         stopNotifications(): Promise<void>;
         toString(): Promise<string>;
@@ -75,6 +75,11 @@ declare namespace NodeBle {
         destroy(): void;
         bluetooth: Bluetooth;
     };
+
+    interface WriteValueOptions {
+        offset?: number;
+        type?: 'reliable' | 'request' | 'command';
+    }
 }
 
 export = NodeBle;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ declare namespace NodeBle {
         getFlags(): Promise<string[]>;
         isNotifying(): Promise<boolean>;
         readValue(offset?: number): Promise<Buffer>;
-        writeValue(buffer: Buffer, options?: WriteValueOptions): Promise<void>;
+        writeValue(buffer: Buffer, optionsOrOffset?: number | WriteValueOptions): Promise<void>;
         startNotifications(): Promise<void>;
         stopNotifications(): Promise<void>;
         toString(): Promise<string>;

--- a/test/GattCharacteristic.spec.js
+++ b/test/GattCharacteristic.spec.js
@@ -19,9 +19,6 @@ jest.doMock('../src/BusHelper', () => {
 const buildTypedValue = require('../src/buildTypedValue')
 const GattCharacteristic = require('../src/GattCharacteristic')
 const dbus = Symbol('dbus')
-const writeValueOptions = (offset = 0, type = 'reliable') => {
-  return { offset: buildTypedValue('uint16', offset), type: buildTypedValue('string', type) }
-}
 
 test('props', async () => {
   const characteristic = new GattCharacteristic(dbus, 'hci0', 'dev_00_00_00_00_00_00', 'characteristic0006', 'char008')
@@ -39,8 +36,15 @@ test('props', async () => {
 
 test('read/write', async () => {
   const characteristic = new GattCharacteristic(dbus, 'hci0', 'dev_00_00_00_00_00_00', 'characteristic0006', 'char008')
+  const writeValueOptions = (offset = 0, type = 'reliable') => {
+    return { offset: buildTypedValue('uint16', offset), type: buildTypedValue('string', type) }
+  }
 
   await expect(characteristic.writeValue('not_a_buffer')).rejects.toThrow('Only buffers can be wrote')
+
+  await expect(characteristic.writeValue(Buffer.from('hello'), 5)).resolves.toBeUndefined()
+  expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions(5))
+
   await expect(characteristic.writeValue(Buffer.from('hello'))).resolves.toBeUndefined()
   expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions())
 


### PR DESCRIPTION
I saw closed [PR](https://github.com/chrvadala/node-ble/pull/5) with changes related to my current problem.

I faced an issue while using type `reliable` for `writeValue`. I update a little bit options for this method, all changes according to [Bluez Gatt-Api](https://github.com/hadess/bluez/blob/master/doc/gatt-api.txt)