### PR TITLE
Extend listener removal in BusHelper

### DIFF
--- a/src/BusHelper.js
+++ b/src/BusHelper.js
@@ -97,6 +97,13 @@ class BusHelper extends EventEmitter {
     return this._ifaceProxy[methodName](...args)
   }
 
+  removeListeners () {
+    this.removeAllListeners('PropertiesChanged')
+    if (this._propsProxy !== null) {
+      this._propsProxy.removeAllListeners('PropertiesChanged')
+    }
+  }
+
   static buildChildren (path, nodes) {
     if (path === '/') path = ''
     const children = new Set()

--- a/src/Device.js
+++ b/src/Device.js
@@ -119,7 +119,7 @@ class Device extends EventEmitter {
    */
   async disconnect () {
     await this.helper.callMethod('Disconnect')
-    this.helper.removeAllListeners('PropertiesChanged') // might be improved
+    this.helper.removeListeners()
   }
 
   /**

--- a/test/Device.spec.js
+++ b/test/Device.spec.js
@@ -13,6 +13,7 @@ jest.doMock('../src/BusHelper', () => {
       this.waitPropChange = jest.fn()
       this.children = jest.fn()
       this.callMethod = jest.fn()
+      this.removeListeners = jest.fn()
     }
   }
 })


### PR DESCRIPTION
Hello,

if the intended use of `Device.disconnect` also is to clean up the remaining event listeners this PR extends this to include the leftover `BusHelper._propsProxy` event listeners adding a new function `BusHelper.removeListeners` for this purpose.

This seems to do it for my current issue in #35.