### PR TITLE
Adding new method for listing all available (powered) adapters

### DIFF
--- a/src/Bluetooth.js
+++ b/src/Bluetooth.js
@@ -51,6 +51,24 @@ class Bluetooth {
 
     return new Adapter(this.dbus, adapter)
   }
+
+  /**
+   * List all available (powered) adapters
+   * @async
+   * @returns {Promise<Adapter[]>}
+   */
+  async activeAdapters () {
+    const adapterNames = await this.adapters()
+    const allAdapters = await Promise.allSettled(adapterNames.map(async name => {
+      const adapter = await this.getAdapter(name)
+      const isPowered = await adapter.isPowered()
+      return { adapter, isPowered }
+    }))
+
+    return allAdapters
+      .filter(item => item.status === 'fulfilled' && item.value.isPowered)
+      .map(item => item.value.adapter)
+  }
 }
 
 module.exports = Bluetooth

--- a/test/Bluetooth.spec.js
+++ b/test/Bluetooth.spec.js
@@ -44,3 +44,26 @@ describe('defaultAdapter', () => {
     expect(Adapter).toHaveBeenCalledWith(dbus, 'hci0')
   })
 })
+
+describe('getActiveAdapters', () => {
+  it('should return only active adapters', async () => {
+    const hci0 = new Adapter(dbus, 'hci0')
+    hci0.isPowered = async () => false
+    hci0.getName = async () => 'hci0'
+
+    const hci1 = new Adapter(dbus, 'hci1')
+    hci1.isPowered = async () => true
+    hci1.getName = async () => 'hci1'
+
+    const bluetooth = new Bluetooth(dbus)
+
+    const adapters = { hci0, hci1 }
+    bluetooth.getAdapter = async name => adapters[name]
+    bluetooth.helper.children.mockReturnValue(['hci0', 'hci1'])
+
+    const result = await bluetooth.activeAdapters()
+
+    expect(result.length).toEqual(1)
+    await expect(result[0].getName()).resolves.toEqual('hci1')
+  })
+})


### PR DESCRIPTION
Context:

In machines with multiple bluetooth adapters, the method `defaultAdapter` (Bluetooth.js) considers all adapters, regardless of their power status, and returns the first item of the list. This behavior is causing errors in client code when the first adapter (hci0) is offline.

To avoid breaking the current behavior of `defaultAdapter`, I created a new method, `activeAdapters`, which will return the list of usable (`isPowered` == true) adapters. Then the client is able to choose which adapter to use.