### PR TITLE
add `writeValueWithoutResponse` and `writeValueWithResponse` methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -354,6 +354,8 @@ GattCharacteristic class interacts with a GATT characteristic.
     * [.isNotifying()](#GattCharacteristic+isNotifying) ⇒ <code>boolean</code>
     * [.readValue([offset])](#GattCharacteristic+readValue) ⇒ <code>Buffer</code>
     * [.writeValue(value, [optionsOrOffset])](#GattCharacteristic+writeValue)
+    * [.writeValueWithoutResponse(value, [offset])](#GattCharacteristic+writeValueWithoutResponse) ⇒ <code>Promise</code>
+    * [.writeValueWithResponse(value, [offset])](#GattCharacteristic+writeValueWithResponse) ⇒ <code>Promise</code>
     * [.startNotifications()](#GattCharacteristic+startNotifications)
     * ["valuechanged"](#GattCharacteristic+event_valuechanged)
 
@@ -399,6 +401,30 @@ Write the value of the characteristic.
 | [optionsOrOffset] | <code>number</code> \| <code>Object</code> | <code>0</code> | Starting offset or writing options. |
 | [optionsOrOffset.offset] | <code>number</code> | <code>0</code> | Starting offset. |
 | [optionsOrOffset.type] | [<code>WritingMode</code>](#WritingMode) | <code>reliable</code> | Writing mode |
+
+<a name="GattCharacteristic+writeValueWithoutResponse"></a>
+
+### gattCharacteristic.writeValueWithoutResponse(value, [offset]) ⇒ <code>Promise</code>
+Write the value of the characteristic without waiting for the response.
+
+**Kind**: instance method of [<code>GattCharacteristic</code>](#GattCharacteristic)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| value | <code>Buffer</code> |  | Buffer containing the characteristic value. |
+| [offset] | <code>number</code> | <code>0</code> | Starting offset. |
+
+<a name="GattCharacteristic+writeValueWithResponse"></a>
+
+### gattCharacteristic.writeValueWithResponse(value, [offset]) ⇒ <code>Promise</code>
+Write the value of the characteristic and wait for the response.
+
+**Kind**: instance method of [<code>GattCharacteristic</code>](#GattCharacteristic)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| value | <code>Buffer</code> |  | Buffer containing the characteristic value. |
+| [offset] | <code>number</code> | <code>0</code> | Starting offset. |
 
 <a name="GattCharacteristic+startNotifications"></a>
 

--- a/src/GattCharacteristic.js
+++ b/src/GattCharacteristic.js
@@ -81,6 +81,26 @@ class GattCharacteristic extends EventEmitter {
   }
 
   /**
+   * Write the value of the characteristic without waiting for the response.
+   * @param {Buffer} value - Buffer containing the characteristic value.
+   * @param {number} [offset = 0] - Starting offset.
+   * @returns {Promise}
+   */
+  async writeValueWithoutResponse (value, offset = 0) {
+    return this.writeValue(value, { offset, type: 'command' })
+  }
+
+  /**
+   * Write the value of the characteristic and wait for the response.
+   * @param {Buffer} value - Buffer containing the characteristic value.
+   * @param {number} [offset = 0] - Starting offset.
+   * @returns {Promise}
+   */
+  async writeValueWithResponse (value, offset = 0) {
+    return this.writeValue(value, { offset, type: 'request' })
+  }
+
+  /**
    * Starts a notification session from this characteristic.
    * It emits valuechanged event when receives a notification.
    */

--- a/test/GattCharacteristic.spec.js
+++ b/test/GattCharacteristic.spec.js
@@ -41,6 +41,8 @@ test('read/write', async () => {
   }
 
   await expect(characteristic.writeValue('not_a_buffer')).rejects.toThrow('Only buffers can be wrote')
+  await expect(characteristic.writeValueWithResponse('not_a_buffer')).rejects.toThrow('Only buffers can be wrote')
+  await expect(characteristic.writeValueWithoutResponse('not_a_buffer')).rejects.toThrow('Only buffers can be wrote')
 
   await expect(characteristic.writeValue(Buffer.from('hello'), 5)).resolves.toBeUndefined()
   expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions(5))
@@ -56,6 +58,12 @@ test('read/write', async () => {
 
   await expect(characteristic.writeValue(Buffer.from('hello'), 'incorrect argument')).resolves.toBeUndefined()
   expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions())
+
+  await expect(characteristic.writeValueWithResponse(Buffer.from('hello'))).resolves.toBeUndefined()
+  expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions(0, 'request'))
+
+  await expect(characteristic.writeValueWithoutResponse(Buffer.from('hello'))).resolves.toBeUndefined()
+  expect(characteristic.helper.callMethod).toHaveBeenCalledWith('WriteValue', expect.anything(), writeValueOptions(0, 'command'))
 
   characteristic.helper.callMethod.mockResolvedValueOnce([255, 100, 0])
   await expect(characteristic.readValue()).resolves.toEqual(Buffer.from([255, 100, 0]))


### PR DESCRIPTION
The [WebBluetooth specs](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothRemoteGATTCharacteristic/writeValue) deprecated `writeValue()`. So I added `writeValueWithoutResponse` and `writeValueWithResponse` to be back on par with the spec