### PR TITLE
Add timeout and discoveryInterval optional parameters Adapter.waitDevice in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,7 +61,7 @@ declare namespace NodeBle {
         stopDiscovery(): Promise<void>;
         devices(): Promise<string[]>;
         getDevice(uuid: string): Promise<Device>;
-        waitDevice(uuid: string): Promise<Device>;
+        waitDevice(uuid: string, timeout?: number, discoveryInterval?: number): Promise<Device>;
         toString(): Promise<string>;
     }
 


### PR DESCRIPTION
`Adapter.waitDevice` supports two optional parameters in the docs, however these don't appear in the `index.d.ts` file, making them unusable in Typescript. I've added them here.