### PR TITLE
Add type declarations for the methods `writeValueWithoutResponse` and `writeValueWithResponse`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@ declare namespace NodeBle {
         readValue(offset?: number): Promise<Buffer>;
         writeValue(buffer: Buffer, optionsOrOffset?: number | WriteValueOptions): Promise<void>;
         writeValueWithoutResponse(buffer: Buffer, offset?: number): Promise<void>;
-        writeValueWithResponse(buffer: Buffer, offset? number): Promise<void>;
+        writeValueWithResponse(buffer: Buffer, offset?: number): Promise<void>;
         startNotifications(): Promise<void>;
         stopNotifications(): Promise<void>;
         toString(): Promise<string>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,8 @@ declare namespace NodeBle {
         isNotifying(): Promise<boolean>;
         readValue(offset?: number): Promise<Buffer>;
         writeValue(buffer: Buffer, optionsOrOffset?: number | WriteValueOptions): Promise<void>;
+        writeValueWithoutResponse(buffer: Buffer, offset?: number): Promise<void>;
+        writeValueWithResponse(buffer: Buffer, offset? number): Promise<void>;
         startNotifications(): Promise<void>;
         stopNotifications(): Promise<void>;
         toString(): Promise<string>;


### PR DESCRIPTION
Add type declarations for the methods `writeValueWithoutResponse` and `writeValueWithResponse` that were added to `GattCharacteristic` with https://github.com/chrvadala/node-ble/pull/47.

I've tried to use these new methods in an application and the TypeScript compiler complained that they didn't exist on `GattCharacteristic`.

I've edited `index.d.ts` in the web browser with Github's web interface which doesn't check for correctness, so I hope I got the declarations right.