### PR TITLE
Add function for get ManufacturerData and AdvertisingData

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -220,6 +220,8 @@ Device class interacts with a remote device.
     * [.getAlias()](#Device+getAlias) ⇒ <code>string</code>
     * [.getRSSI()](#Device+getRSSI) ⇒ <code>number</code>
     * [.getTXPower()](#Device+getTXPower) ⇒ <code>number</code>
+    * [.getManufacturerData()](#Device+getManufacturerData) ⇒ <code>Object.&lt;string, any&gt;</code>
+    * [.getAdvertisingData()](#Device+getAdvertisingData) ⇒ <code>Object.&lt;string, any&gt;</code>
     * [.isPaired()](#Device+isPaired) ⇒ <code>boolean</code>
     * [.isConnected()](#Device+isConnected) ⇒ <code>boolean</code>
     * [.pair()](#Device+pair)
@@ -265,6 +267,18 @@ Received Signal Strength Indicator of the remote device
 
 ### device.getTXPower() ⇒ <code>number</code>
 Advertised transmitted power level.
+
+**Kind**: instance method of [<code>Device</code>](#Device)  
+<a name="Device+getManufacturerData"></a>
+
+### device.getManufacturerData() ⇒ <code>Object.&lt;string, any&gt;</code>
+Advertised transmitted manufacturer data.
+
+**Kind**: instance method of [<code>Device</code>](#Device)  
+<a name="Device+getAdvertisingData"></a>
+
+### device.getAdvertisingData() ⇒ <code>Object.&lt;string, any&gt;</code>
+Advertised transmitted data.
 
 **Kind**: instance method of [<code>Device</code>](#Device)  
 <a name="Device+isPaired"></a>

--- a/src/Device.js
+++ b/src/Device.js
@@ -66,6 +66,22 @@ class Device extends EventEmitter {
   }
 
   /**
+   * Advertised transmitted manufacturer data.
+   * @returns {Object.<string, any>}
+   */
+  async getManufacturerData () {
+    return this.helper.prop('ManufacturerData')
+  }
+
+  /**
+   * Advertised transmitted data.
+   * @returns {Object.<string, any>}
+   */
+  async getAdvertisingData () {
+    return this.helper.prop('AdvertisingData')
+  }
+
+  /**
    * Indicates if the remote device is paired.
    * @returns {boolean}
    */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,6 +39,8 @@ declare namespace NodeBle {
         getAddressType(): Promise<string>;
         getAlias(): Promise<string>;
         getRSSI(): Promise<string>;
+        getManufacturerData(): Promise<{[key:string]:any}>;
+        getAdvertisingData(): Promise<{[key:string]:any}>;
         isPaired(): Promise<string>;
         isConnected(): Promise<string>;
         pair(): Promise<void>;
@@ -71,7 +73,7 @@ declare namespace NodeBle {
         adapters(): Promise<string[]>;
         defaultAdapter(): Promise<Adapter>;
         getAdapter(adapter: string): Promise<Adapter>;
-    } 
+    }
 
     function createBluetooth(): {
         destroy(): void;

--- a/test/Device.spec.js
+++ b/test/Device.spec.js
@@ -33,7 +33,8 @@ test('props', async () => {
     Alias: '_alias_',
     RSSI: 100,
     TxPower: 50,
-
+    ManufacturerData: { 1: { signature: 'ay', value: { type: 'Buffer', data: Buffer.from('test') } } },
+    AdvertisingData: { 2: { signature: 'ay', value: { type: 'Buffer', data: Buffer.from('test') } } },
     Paired: true,
     Connected: true
   }[value])))
@@ -44,6 +45,8 @@ test('props', async () => {
   await expect(device.getAlias()).resolves.toEqual('_alias_')
   await expect(device.getRSSI()).resolves.toEqual(100)
   await expect(device.getTXPower()).resolves.toEqual(50)
+  await expect(device.getManufacturerData()).resolves.toMatchObject({ 1: { signature: 'ay', value: { type: 'Buffer', data: Buffer.from('test') } } })
+  await expect(device.getAdvertisingData()).resolves.toMatchObject({ 2: { signature: 'ay', value: { type: 'Buffer', data: Buffer.from('test') } } })
 
   await expect(device.isConnected()).resolves.toEqual(true)
   await expect(device.isPaired()).resolves.toEqual(true)


### PR DESCRIPTION
Add function for get ManufacturerData and AdvertisingData to the Device Interface. 
This is the same as PR #61 with the changes commented here #53. I created a new pull-request because the #61 was not made by me.