### PR TITLE
Pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ It leverages the `bluez` driver, a component supported by the following platform
 - Ubuntu
 - Debian
 
-```sh
-sudo apt install dbus bluetooth bluez libbluetooth-dev libudev-dev
-```
-
 # Install
 ```sh
 npm install node-ble

--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ Bluetooth Low Energy (BLE) library written with pure Node.js (no bindings) - bak
   - [GattCharacteristic](https://github.com/chrvadala/node-ble/blob/main/docs/api.md#GattCharacteristic)
 
 # Pre-requisites
-This library works on many architectures supported by Linux. However Windows and Mac OS are currently *not* supported.
+This library works on many architectures supported by Linux. However Windows and Mac OS are [*not* supported](https://github.com/chrvadala/node-ble/issues/31).
 
 It leverages the `bluez` driver, a component supported by the following platforms and distributions <https://www.bluez.org/about>.
 
 *node-ble* has been tested on the following architectures:
 - Raspbian
 - Ubuntu
+- Debian
 
 ```sh
-sudo apt install bluetooth bluez libbluetooth-dev libudev-dev
+sudo apt install dbus bluetooth bluez libbluetooth-dev libudev-dev
 ```
 
 # Install

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Bluetooth Low Energy (BLE) library written with pure Node.js (no bindings) - bak
   - [GattService](https://github.com/chrvadala/node-ble/blob/main/docs/api.md#GattService)
   - [GattCharacteristic](https://github.com/chrvadala/node-ble/blob/main/docs/api.md#GattCharacteristic)
 
+# Pre-requisites
+This library works on many architectures supported by Linux. However Windows and Mac OS are currently *not* supported.
+
+It leverages the `bluez` driver, a component supported by the following platforms and distributions <https://www.bluez.org/about>.
+
+*node-ble* has been tested on the following architectures:
+- Raspbian
+- Ubuntu
+
+```sh
+sudo apt install bluetooth bluez libbluetooth-dev libudev-dev
+```
+
 # Install
 ```sh
 npm install node-ble
@@ -100,13 +113,6 @@ await device.disconnect()
 destroy()
 ```
 
-# Compatibility
-This library works on many architectures supported by Linux.
-It leverages on Bluez driver, a component supported by the following platforms and distributions https://www.bluez.org/about
-
-*Node-ble* has been tested on the following environment:
-- Raspbian
-- Ubuntu
 # Changelog
 - **0.x** - Beta version
 - **1.0** - First official version


### PR DESCRIPTION
Clarification for #31.

To prevent frustration for Windows/Mac OS users, I moved the compatibility section to the top and added `apt` install requirements.

- Move the compatibility section to the top.
- Explicitly mention that Windows and Mac OS are not supported
- Mention `apt` install
- Added Debian as a tested environment