### PR TITLE
Fix a race condition in startNotification with the "valuechanged" event notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ console.log(buffer)
 ```javascript
 const service2 = await gattServer.getPrimaryService('uuid')
 const characteristic2 = await service2.getCharacteristic('uuid')
-await characteristic2.startNotifications()
 characteristic2.on('valuechanged', buffer => {
   console.log(buffer)
 })
-await characteristic2.stopNotifications()
+await characteristic2.startNotifications()
 ```
 
 ## STEP 5: Disconnect
-When you have done you can disconnect and destroy the session.
+When you have done you can stop notifications, disconnect and destroy the session.
 ```javascript
+await characteristic2.stopNotifications()
 await device.disconnect()
 destroy()
 ```

--- a/src/GattCharacteristic.js
+++ b/src/GattCharacteristic.js
@@ -105,8 +105,6 @@ class GattCharacteristic extends EventEmitter {
    * It emits valuechanged event when receives a notification.
    */
   async startNotifications () {
-    await this.helper.callMethod('StartNotify')
-
     const cb = (propertiesChanged) => {
       if ('Value' in propertiesChanged) {
         const { value } = propertiesChanged.Value
@@ -115,6 +113,8 @@ class GattCharacteristic extends EventEmitter {
     }
 
     this.helper.on('PropertiesChanged', cb)
+
+    await this.helper.callMethod('StartNotify')
   }
 
   async stopNotifications () {

--- a/test/GattCharacteristic.spec.js
+++ b/test/GattCharacteristic.spec.js
@@ -103,13 +103,13 @@ test('event:valuechanged', async () => {
 
 test('race condition between event:valuechanged / startNotification', async () => {
   const characteristic = new GattCharacteristic(dbus, 'hci0', 'dev_00_00_00_00_00_00', 'characteristic0006', 'char008')
-  const cb = jest.fn(value => {});
+  const cb = jest.fn(value => {})
   characteristic.on('valuechanged', cb)
 
   // Wrap the call to StartNotify with an early property change to check this event is not lost in a race condition
   characteristic.helper.callMethod.mockImplementationOnce(async (method) => {
-    if (method != "StartNotify") {
-      throw new Error("Unexpected state in unit test")
+    if (method !== 'StartNotify') {
+      throw new Error('Unexpected state in unit test')
     }
 
     await characteristic.helper.callMethod('StartNotify')
@@ -122,13 +122,13 @@ test('race condition between event:valuechanged / startNotification', async () =
 
   // Start notifications, wait 200ms and send a second event
   characteristic.startNotifications()
-  await new Promise((r) => setTimeout(r, 200));
+  await new Promise((resolve) => setTimeout(resolve, 200))
   characteristic.helper.emit('PropertiesChanged',
     { Value: { signature: 'ay', value: [0x62, 0x61, 0x72] } } // means bar
   )
 
   // Check the mocked callback function has been called twice
-  expect(cb.mock.calls).toHaveLength(2);
+  expect(cb.mock.calls).toHaveLength(2)
 
   // Cleanup
   characteristic.off('valuechanged', cb)

--- a/test/GattCharacteristic.spec.js
+++ b/test/GattCharacteristic.spec.js
@@ -100,3 +100,36 @@ test('event:valuechanged', async () => {
 
   await characteristic.stopNotifications()
 })
+
+test('race condition between event:valuechanged / startNotification', async () => {
+  const characteristic = new GattCharacteristic(dbus, 'hci0', 'dev_00_00_00_00_00_00', 'characteristic0006', 'char008')
+  const cb = jest.fn(value => {});
+  characteristic.on('valuechanged', cb)
+
+  // Wrap the call to StartNotify with an early property change to check this event is not lost in a race condition
+  characteristic.helper.callMethod.mockImplementationOnce(async (method) => {
+    if (method != "StartNotify") {
+      throw new Error("Unexpected state in unit test")
+    }
+
+    await characteristic.helper.callMethod('StartNotify')
+
+    // Send the first event right after StartNotify
+    characteristic.helper.emit('PropertiesChanged',
+      { Value: { signature: 'ay', value: [0x62, 0x61, 0x72] } } // means bar
+    )
+  })
+
+  // Start notifications, wait 200ms and send a second event
+  characteristic.startNotifications()
+  await new Promise((r) => setTimeout(r, 200));
+  characteristic.helper.emit('PropertiesChanged',
+    { Value: { signature: 'ay', value: [0x62, 0x61, 0x72] } } // means bar
+  )
+
+  // Check the mocked callback function has been called twice
+  expect(cb.mock.calls).toHaveLength(2);
+
+  // Cleanup
+  characteristic.off('valuechanged', cb)
+})


### PR DESCRIPTION
This Pull Request is a proposal to fix #72 by removing a race condition between startNotification and the "valuechanged" event notifications.

The unit test wraps the `StartNotify` call with an early event emission.
An assertion is positioned to ensure that this early event is not lost.

With the original code, the new unit test fails with:

```
$ npm run test:jest

> node-ble@1.12.0 test:jest
> jest --testPathIgnorePatterns=test-e2e/

 PASS  test/GattService.spec.js
 PASS  test/buildTypedValue.spec.js
 PASS  test/GattServer.spec.js
 PASS  test/parseDict.spec.js
 PASS  test/Device.spec.js
 PASS  test/Bluetooth.spec.js
 PASS  test/BusHelper.spec.js
 FAIL  test/GattCharacteristic.spec.js
  ● race condition between event:valuechanged / startNotification

    expect(received).toHaveLength(expected)

    Expected length: 2
    Received length: 1
    Received array:  [[{"data": [98, 97, 114], "type": "Buffer"}]]

      129 |
      130 |   // Check the mocked callback function has been called twice
    > 131 |   expect(cb.mock.calls).toHaveLength(2);
          |                         ^
      132 |   
      133 |   // Cleanup
      134 |   characteristic.off('valuechanged', cb)

      at Object.toHaveLength (test/GattCharacteristic.spec.js:131:25)

 PASS  test/Adapter.spec.js

Test Suites: 1 failed, 8 passed, 9 total
Tests:       1 failed, 37 passed, 38 total
Snapshots:   0 total
Time:        1.84 s, estimated 2 s
Ran all test suites.
```

With the proposed code, all tests are passing.