### PR TITLE
Unit test for a race condition in Device.js / disconnect()

### DIFF
--- a/src/Device.js
+++ b/src/Device.js
@@ -144,7 +144,7 @@ class Device extends EventEmitter {
    */
   async disconnect () {
     await this.helper.callMethod('Disconnect')
-    this.helper.removeListeners()
+    this.helper.removeAllListeners()
   }
 
   /**

--- a/test/Device.spec.js
+++ b/test/Device.spec.js
@@ -13,7 +13,6 @@ jest.doMock('../src/BusHelper', () => {
       this.waitPropChange = jest.fn()
       this.children = jest.fn()
       this.callMethod = jest.fn()
-      this.removeListeners = jest.fn()
     }
   }
 })
@@ -113,4 +112,26 @@ test('event:valuechanged', async () => {
   expect(disconnectedFn).toHaveBeenCalledWith({ connected: false })
 
   await device.disconnect()
+})
+
+test('race condition in Device.js / disconnect()', async () => {
+  const device = new Device(dbus, 'hci0', 'dev_00_00_00_00_00_00')
+
+  await device.connect()
+
+  const disconnectedFn = jest.fn()
+  device.on('disconnect', disconnectedFn)
+  
+  await device.disconnect()
+
+  // Send the disconnect event slightly after the call to disconnect()
+  device.helper.emit('PropertiesChanged',
+    { Connected: { signature: 'b', value: false } }
+  )
+
+  // Check that the disconnect event has been received
+  expect(disconnectedFn).toHaveBeenCalledWith({ connected: false })
+
+  // Cleanup
+  device.off('disconnect', disconnectedFn)
 })


### PR DESCRIPTION
This Pull Request is a proposal for a unit test exhibiting the behavior described in #73.

To implement this unit test, I had to replace in the actual code the call to `removeListeners` with a call to `removeAllListeners`.

In the unit tests, the **EventEmitter** implementation from nodejs is used as-is (no mock). But the `removeListeners` method is not part of that implementation. Only `removeAllListeners` is is officially part of the **EventEmitter** class ([documentation](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter)).

With the following patch, the unit test is passing.

```diff
  /**
   * Connect to remote device
   */
  async connect () {
    const cb = (propertiesChanged) => {
      if ('Connected' in propertiesChanged) {
        const { value } = propertiesChanged.Connected
        if (value) {
          this.emit('connect', { connected: true })
        } else {
          this.emit('disconnect', { connected: false })
+         this.helper.removeAllListeners()
        }
      }
    }

    this.helper.on('PropertiesChanged', cb)
    await this.helper.callMethod('Connect')
  }

  /**
   * Disconnect remote device
   */
  async disconnect () {
    await this.helper.callMethod('Disconnect')
-   this.helper.removeAllListeners()
  }
```