### PR TITLE
Add parameter to control BlueZ data duplication while scanning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -110,10 +110,17 @@ Indicates that a device discovery procedure is active.
 **Kind**: instance method of [<code>Adapter</code>](#Adapter)  
 <a name="Adapter+startDiscovery"></a>
 
-### adapter.startDiscovery()
+### adapter.startDiscovery([duplicateData])
 This method starts the device discovery session.
 
-**Kind**: instance method of [<code>Adapter</code>](#Adapter)  
+The `duplicateData` parameter can be used to control [BlueZ duplicate detection](https://web.git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/org.bluez.Adapter.rst).
+
+**Kind**: instance method of [<code>Adapter</code>](#Adapter)
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [duplicateData] | `boolean` | `true` | Disables duplicate detection of advertisement data. When enabled PropertiesChanged signals will be generated for either ManufacturerData and ServiceData everytime they are discovered. |
+
 <a name="Adapter+stopDiscovery"></a>
 
 ### adapter.stopDiscovery()

--- a/src/Adapter.js
+++ b/src/Adapter.js
@@ -73,15 +73,22 @@ class Adapter {
 
   /**
    * This method starts the device discovery session.
+   * @param {boolean} duplicateData - Disables duplicate detection of
+   * advertisement data.
+   *
+   * When enabled PropertiesChanged signals will be generated for either
+   * ManufacturerData and ServiceData everytime they are discovered.
+   *
    * @async
    */
-  async startDiscovery () {
+  async startDiscovery (duplicateData = true) {
     if (await this.isDiscovering()) {
       throw new Error('Discovery already in progress')
     }
 
     await this.helper.callMethod('SetDiscoveryFilter', {
-      Transport: buildTypedValue('string', 'le')
+      Transport: buildTypedValue('string', 'le'),
+      DuplicateData: buildTypedValue('boolean', duplicateData)
     })
     await this.helper.callMethod('StartDiscovery')
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,7 @@ declare namespace NodeBle {
         getAlias(): Promise<string>;
         isPowered(): Promise<boolean>;
         isDiscovering(): Promise<boolean>;
-        startDiscovery(): Promise<void>;
+        startDiscovery(duplicateData?: boolean): Promise<void>;
         stopDiscovery(): Promise<void>;
         devices(): Promise<string[]>;
         getDevice(uuid: string): Promise<Device>;


### PR DESCRIPTION
This pull request adds the option to control BlueZ's data duplication according to https://github.com/bluez/bluez/blob/4465c577778d812702d752dfd2812e25a2f69b31/doc/org.bluez.Adapter.rst?plain=1#L128

While de-duplication seems to be off on a few distributions, it is on on others, essentially making continous monitoring of advertised data impossible. Also, since the offizial BlueZ documentation regarded `true` to be the default for duplicate data, I set this option to `true` as default for node-ble as well in order to preserve what I believe was the intended default operation until this point.

Related to this, documentation on DuplicateData was outdated and has now been changed: https://github.com/bluez/bluez/issues/1113

I also updated the API documentation and TypeScript typings accordingly.